### PR TITLE
Fix HIBC parsing without batch field in $$8/9 notation

### DIFF
--- a/BarcodeParserBuilder.UnitTests/Barcodes/HIBC/HibcBarcodeParserBuilderTestFixture.cs
+++ b/BarcodeParserBuilder.UnitTests/Barcodes/HIBC/HibcBarcodeParserBuilderTestFixture.cs
@@ -199,7 +199,19 @@ public class HibcBarcodeParserBuilderTestFixture : BaseBarcodeTestFixture
                 ProductionDate = new TestBarcodeDateTime(new DateTime(2011, 12, 31), "20111231", "yyyyMMdd"),
                 Quantity = 500
             }
-        },        
+        },
+
+        //2D - example of quantity without expiration date
+        {
+            "+EHWD3551419/$$900100F",
+            new HibcBarcode()
+            {
+                LabelerIdentificationCode = "EHWD",
+                ProductCode = TestProductCode.CreateProductCode<HibcProductCode>("355141"),
+                UnitOfMeasure = 9,
+                Quantity = 100
+            }
+        },
     };
 
     public static TheoryData<string, HibcBarcode> ValidHibcBuildingBarcodes() => new()
@@ -411,6 +423,18 @@ public class HibcBarcodeParserBuilderTestFixture : BaseBarcodeTestFixture
                 UnitOfMeasure = 0,
                 ExpirationDate = new TestBarcodeDateTime(new DateTime(2026, 04, 13), "20260413", "yyyyMMdd"),
                 BatchNumber = "230513",
+            }
+        },
+        
+        //2D - example of quantity without expiration date
+        {
+            "+EHWD3551419/Q100/",
+            new HibcBarcode()
+            {
+                LabelerIdentificationCode = "EHWD",
+                ProductCode = TestProductCode.CreateProductCode<HibcProductCode>("355141"),
+                UnitOfMeasure = 9,
+                Quantity = 100
             }
         },
     };

--- a/BarcodeParserBuilder/Barcodes/HIBC/HibcBarcodeParserBuilder.cs
+++ b/BarcodeParserBuilder/Barcodes/HIBC/HibcBarcodeParserBuilder.cs
@@ -305,7 +305,7 @@ public class HibcBarcodeParserBuilder : BaseBarcodeParserBuilder<HibcBarcode>
 
                         //$$2 - $$6 -> dated batch or serial line
                         //$$7 -> only batch/serial
-                        //$$8 - $$9 -> quantity + (optional) date & batch/serial lines
+                        //$$8 - $$9 -> quantity + (optional) date + (optional) batch/serial lines
                         //in hibc specs 2.6 $$8 & $$9 have been depricated, and are replaced with /Q, but in <= 2.5 they are allowed...
                         //flippin' hibc specs man
                         if (isMultiDataLine && int.TryParse(segmentData.First().ToString(), out var formatNumber))
@@ -313,12 +313,17 @@ public class HibcBarcodeParserBuilder : BaseBarcodeParserBuilder<HibcBarcode>
                             var format = HibcBarcodeSegmentFormat.SegmentFormats[formatNumber];
                             switch (formatNumber)
                             {
-                                //quantity ( + optional date ) + batch/serial
+                                //quantity ( + optional date ) ( + optional batch/serial )
                                 case 8:
                                 case 9:
                                     segmentData = segmentData[1..];
                                     barcode.Quantity = int.Parse(segmentData[..format.Length]);
                                     segmentData = segmentData[format.Length..];
+
+                                    //neither date nor batch follow the quantity
+                                    if (segmentData.Length < 1)
+                                        break;
+
                                     if (int.TryParse(segmentData.First().ToString(), out var newFormat))
                                     {
                                         formatNumber = int.Parse(segmentData.First().ToString());


### PR DESCRIPTION
The HIBC Parser in $$8 and $$9 notation fails when no date and no batch field follow the quantity.
In the <2.6 specs this is allowed. In that case no formatNumber, no date and no batch number follows the quantity before the end of the segment and an exception is thrown at segmentData.First().ToString() as segmentData.First() returns NULL.
