### PR TITLE
Add GS1 Application Identifiers 400-403

### DIFF
--- a/BarcodeParserBuilder.UnitTests/Barcodes/GS1/GS1BarcodeParserBuilderTestFixture.cs
+++ b/BarcodeParserBuilder.UnitTests/Barcodes/GS1/GS1BarcodeParserBuilderTestFixture.cs
@@ -62,6 +62,26 @@ public class GS1BarcodeParserBuilderTestFixture : BaseBarcodeTestFixture
         else
             result.Fields["314"].Value.Should().BeNull();
 
+        if (expectedBarcode.Fields["400"].Value != null)
+            (result!.Fields["400"].Value).Should().Be(expectedBarcode.Fields["400"].Value);
+        else
+            result!.Fields["400"].Value.Should().BeNull();
+
+        if (expectedBarcode.Fields["401"].Value != null)
+            (result!.Fields["401"].Value).Should().Be(expectedBarcode.Fields["401"].Value);
+        else
+            result!.Fields["401"].Value.Should().BeNull();
+
+        if (expectedBarcode.Fields["402"].Value != null)
+            (result!.Fields["402"].Value).Should().Be(expectedBarcode.Fields["402"].Value);
+        else
+            result!.Fields["402"].Value.Should().BeNull();
+
+        if (expectedBarcode.Fields["403"].Value != null)
+            (result!.Fields["403"].Value).Should().Be(expectedBarcode.Fields["403"].Value);
+        else
+            result!.Fields["403"].Value.Should().BeNull();
+
         if (expectedBarcode.Fields["410"].Value != null)
             (result!.Fields["410"].Value).Should().Be(expectedBarcode.Fields["410"].Value);
         else
@@ -329,6 +349,20 @@ public class GS1BarcodeParserBuilderTestFixture : BaseBarcodeTestFixture
         gs1BarcodeDimension.Fields["313"].SetValue(0.01234); // Deepth in metres
         gs1BarcodeDimension.Fields["314"].SetValue(123456d); // Area in square metres
 
+        var gs1Barcode40x = new GS1Barcode()
+        {
+            ProductCode = TestProductCode.CreateProductCode<GtinProductCode>("03574661451947", (productCode) =>
+            {
+                productCode.Type = ProductCodeType.GTIN;
+                productCode.Value = "357466145194";
+                productCode.Indicator = 0;
+            })
+        };
+        gs1Barcode40x.Fields["400"].SetValue("PO-20250612-ABC123");       // ORDER NUMBER
+        gs1Barcode40x.Fields["401"].SetValue("GINC202506120001SHIPMENT"); // GINC
+        gs1Barcode40x.Fields["402"].SetValue("91234567890123456");        // GSIN
+        gs1Barcode40x.Fields["403"].SetValue("HUB-NYC-AREA5");            // ROUTE
+
         var gs1Barcode41x = new GS1Barcode()
         {
             ProductCode = TestProductCode.CreateProductCode<GtinProductCode>("03574661451947", (productCode) =>
@@ -581,6 +615,11 @@ public class GS1BarcodeParserBuilderTestFixture : BaseBarcodeTestFixture
             {
                $"0103574661451947101724847.1{GroupSeparator}1721033121118165795226{GroupSeparator}31151234563122123456313500123431401234563205354777",
                 gs1BarcodeDimension
+            },
+            //Check prefix 40 AIs
+            {
+                $"0103574661451947400PO-20250612-ABC123{GroupSeparator}401GINC202506120001SHIPMENT{GroupSeparator}40291234567890123456403HUB-NYC-AREA5",
+                gs1Barcode40x
             },
             //Check prefix 41 AIs
             {

--- a/BarcodeParserBuilder/BarcodeParserBuilder.csproj
+++ b/BarcodeParserBuilder/BarcodeParserBuilder.csproj
@@ -51,7 +51,7 @@ When combined with barcode imaging projects like Zxing you can scan, parse, buil
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
     <PackageReference Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/BarcodeParserBuilder/Barcodes/GS1/GS1Barcode.cs
+++ b/BarcodeParserBuilder/Barcodes/GS1/GS1Barcode.cs
@@ -108,7 +108,7 @@ public class GS1Barcode(AimSymbologyIdentifier? symbologyIdentifier) : Barcode(s
         new GS1Field("80"),
         new GS1Field("81"),
         new GS1Field("82"),
-        new GS1Field("90", 90),
+        new GS1Field("90", 30),
         new GS1Field("91", 90),
         new GS1Field("92", 90),
         new GS1Field("93", 90),

--- a/BarcodeParserBuilder/Barcodes/GS1/GS1Barcode.cs
+++ b/BarcodeParserBuilder/Barcodes/GS1/GS1Barcode.cs
@@ -106,7 +106,10 @@ public class GS1Barcode(AimSymbologyIdentifier? symbologyIdentifier) : Barcode(s
         new GS1Field("395"),                                    // Amount payable per unit of measure single monetary area (variable measure trade item): AI (395n)
 
         // GS1 Application Identifiers starting with digit 4
-        new GS1Field("40"),
+        new GS1Field("400", 30),                                // Customer’s purchase order number
+        new GS1Field("401", 30),                                // Global Identification Number for Consignment (GINC)
+        new FixedLengthGS1Field("402", 17),                     // Global Shipment Identification Number (GSIN)
+        new GS1Field("403", 30),                                // Routing code
         new FixedLengthGS1Field("410", 13),                     // Ship to - Deliver to Global Location Number (GLN)
         new FixedLengthGS1Field("411", 13),                     // Bill to - Invoice to Global Location Number (GLN)
         new FixedLengthGS1Field("412", 13),                     // Purchased from Global Location Number (GLN)

--- a/BarcodeParserBuilder/Barcodes/GS1/GS1Barcode.cs
+++ b/BarcodeParserBuilder/Barcodes/GS1/GS1Barcode.cs
@@ -11,16 +11,39 @@ public class GS1Barcode(AimSymbologyIdentifier? symbologyIdentifier) : Barcode(s
     public override BarcodeType BarcodeType => BarcodeType.GS1;
     protected override FieldCollection BarcodeFields { get; } =
     [
-        new FixedLengthGS1Field("00", 18),
-        new FixedLengthGS1Field<ProductCode?>("01", 14),
-        new FixedLengthGS1Field<ProductCode?>("02", 14),
-        new FixedLengthGS1Field<BarcodeDateTime?>("11", 6),
-        new FixedLengthGS1Field<BarcodeDateTime?>("12", 6),
-        new FixedLengthGS1Field<BarcodeDateTime?>("13", 6),
-        new FixedLengthGS1Field<BarcodeDateTime?>("15", 6),
-        new FixedLengthGS1Field<BarcodeDateTime?>("16", 6),
-        new FixedLengthGS1Field<BarcodeDateTime?>("17", 6),
-        new FixedLengthGS1Field("20", 2),
+        // GS1 Application Identifiers starting with digit 0
+        new FixedLengthGS1Field("00", 18),                      // Identification of a logistic unit (SSCC
+        new FixedLengthGS1Field<ProductCode?>("01", 14),        // Identification of a trade item (GTIN
+        new FixedLengthGS1Field<ProductCode?>("02", 14),        // Identification of trade items contained in a logistic unit
+        
+        // GS1 Application Identifiers starting with digit 1
+        new GS1Field("10", 20),                                 // Batch or lot number
+        new FixedLengthGS1Field<BarcodeDateTime?>("11", 6),     // Production date
+        new FixedLengthGS1Field<BarcodeDateTime?>("12", 6),     // Due date for amount on payment slip
+        new FixedLengthGS1Field<BarcodeDateTime?>("13", 6),     // Packaging date
+        new FixedLengthGS1Field<BarcodeDateTime?>("15", 6),     // Best before date
+        new FixedLengthGS1Field<BarcodeDateTime?>("16", 6),     // Sell by date
+        new FixedLengthGS1Field<BarcodeDateTime?>("17", 6),     // Expiration date
+        
+        // GS1 Application Identifiers starting with digit 2
+        new FixedLengthGS1Field("20", 2),                       // Internal product variant
+        new GS1Field("21", 20),                                 // Serial number
+        new GS1Field("22", 20),                                 // Consumer product variant
+        new GS1Field("235", 28),                                // Third Party Controlled, Serialised Extension of Global Trade Item Number (GTIN) (TPX)
+        new GS1Field("240", 30),                                // Additional product identification assigned by the manufacturer
+        new GS1Field("241", 30),                                // Customer part number
+        new GS1Field("242", 6),                                 // Made-to-Order variation number
+        new GS1Field("243", 20),                                // Packaging component number
+        new GS1Field("250", 30),                                // Secondary serial number
+        new GS1Field("251", 30),                                // Reference to source entity
+        new GS1Field("253", 30),                                // Global Document Type Identifier (GDTI)
+        new GS1Field("254", 20),                                // Global Location Number (GLN) extension component
+        new GS1Field("255", 25),                                // Global Coupon Number (GCN)
+
+        // GS1 Application Identifiers starting with digit 3
+        new GS1Field<int?>("30", 8),                           // Variable count of items
+        // Trade measures: AIs (31nn, 32nn, 35nn, 36nn)
+        // Logistic measures: AIs (33nn, 34nn, 35nn, 36nn)
         new FixedLengthGS1Field<double?>("310", 7),
         new FixedLengthGS1Field<double?>("311", 7),
         new FixedLengthGS1Field<double?>("312", 7),
@@ -74,41 +97,40 @@ public class GS1Barcode(AimSymbologyIdentifier? symbologyIdentifier) : Barcode(s
         new FixedLengthGS1Field<double?>("367", 7),
         new FixedLengthGS1Field<double?>("368", 7),
         new FixedLengthGS1Field<double?>("369", 7),
-        new FixedLengthGS1Field("410", 13),
-        new FixedLengthGS1Field("411", 13),
-        new FixedLengthGS1Field("412", 13),
-        new FixedLengthGS1Field("413", 13),
-        new FixedLengthGS1Field("414", 13),
-        new FixedLengthGS1Field("415", 13),
-        new FixedLengthGS1Field("416", 13),
-        new FixedLengthGS1Field("417", 13),
+        new GS1Field("37"),                                     // Count of trade items or trade item pieces contained in a logistic unit
+        new GS1Field("390"),                                    // Amount payable or coupon value - Single monetary area: AI (390n)
+        new GS1Field("391"),                                    // Amount payable and ISO currency code: AI (391n)
+        new GS1Field<double?>("392", 1, 16),                    // Amount payable for a variable measure trade item – Single monetary area: AI (392n)
+        new GS1Field("393"),                                    // Amount payable for a variable measure trade item and ISO currency code: AI (393n)
+        new GS1Field("394"),                                    // Percentage discount of a coupon: AI (394n)
+        new GS1Field("395"),                                    // Amount payable per unit of measure single monetary area (variable measure trade item): AI (395n)
 
-        new GS1Field("10", 20),
-        new GS1Field("21", 20),
-        new GS1Field("22", 20),
-        new GS1Field("235", 28),
-        new GS1Field("240", 30),
-        new GS1Field("241", 30),
-        new GS1Field("242", 6),
-        new GS1Field("243", 20),
-        new GS1Field<int?>("30", 8),
-        new GS1Field("37"),
-        new GS1Field("390"),
-        new GS1Field("391"),
-        new GS1Field<double?>("392", 1, 16),
-        new GS1Field("393"),
-        new GS1Field("394"),
-        new GS1Field("395"),
+        // GS1 Application Identifiers starting with digit 4
         new GS1Field("40"),
+        new FixedLengthGS1Field("410", 13),                     // Ship to - Deliver to Global Location Number (GLN)
+        new FixedLengthGS1Field("411", 13),                     // Bill to - Invoice to Global Location Number (GLN)
+        new FixedLengthGS1Field("412", 13),                     // Purchased from Global Location Number (GLN)
+        new FixedLengthGS1Field("413", 13),                     // Ship for - Deliver for - Forward to Global Location Number (GLN)
+        new FixedLengthGS1Field("414", 13),                     // Identification of a physical location - Global Location Number (GLN)
+        new FixedLengthGS1Field("415", 13),                     // Global Location Number (GLN) of the invoicing party
+        new FixedLengthGS1Field("416", 13),                     // Global Location Number (GLN) of the production or service location
+        new FixedLengthGS1Field("417", 13),                     // Party Global Location Number (GLN)
         new GS1Field("42"),
         new GS1Field("43"),
+
+        // GS1 Application Identifiers starting with digit 7
         new GS1Field("70"),
         new GS1Field("71"),
         new GS1Field("72"),
+
+        // GS1 Application Identifiers starting with digit 8
         new GS1Field("80"),
         new GS1Field("81"),
         new GS1Field("82"),
-        new GS1Field("90", 30),
+ 
+        // GS1 Application Identifiers starting with digit 9
+        new GS1Field("90", 30),                                 // Information mutually agreed between trading partners
+        // Company internal information: AIs (91 - 99)
         new GS1Field("91", 90),
         new GS1Field("92", 90),
         new GS1Field("93", 90),
@@ -118,11 +140,6 @@ public class GS1Barcode(AimSymbologyIdentifier? symbologyIdentifier) : Barcode(s
         new GS1Field("97", 90),
         new GS1Field("98", 90),
         new GS1Field("99", 90),
-        new GS1Field("250", 30),
-        new GS1Field("251", 30),
-        new GS1Field("253", 30),
-        new GS1Field("254", 20),
-        new GS1Field("255", 25),
     ];
 
     public override AimSymbologyIdentifier? ReaderInformation { get; protected set; }


### PR DESCRIPTION
See issue #22

- fixes max length for AI 90
- removes grouped 40 and split up 40x AIs
- include specific test cases for 40x AIs
- NuGet package updated

This PR also re-orders all AIs according to the Spec[1][2], including comments. This shall help with adding missing or splitting up grouped AIs.
I kept the existing grouped AIs 42, 43, 7x and 8x for now.

[1] [GS1 General Specifications Standard](https://ref.gs1.org/standards/genspecs/)
[2] [GS1 Application Identifiers](https://ref.gs1.org/ai/)